### PR TITLE
Add support clipboard type and non-v3-microarchitecture CPU

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -3,7 +3,6 @@ builds:
   main: ./cmd/
   env:
     - CGO_ENABLED=0
-    - GOAMD64=v3
   ldflags:
   - -s
   - -w

--- a/api/v1alpha1/homerservices_types.go
+++ b/api/v1alpha1/homerservices_types.go
@@ -89,6 +89,9 @@ type Item struct {
 	Url string `json:"url,omitempty"`
 	// Target of the service in homer dashboard
 	Target string `json:"target,omitempty"`
+	// Type of the service in homer dashboard. See https://github.com/bastienwirtz/homer/blob/64629742f7aec7b34e8fc9e6b83282e496c2fb74/docs/configuration.md?plain=1#L150
+	Type string `json:"type,omitempty"`
+	Clipboard string `json:"clipboard,omitempty"` 
 	// Optional color for card to set color directly without custom stylesheet
 	Background string `json:"background,omitempty"`
 }

--- a/helm/homer-k8s/crds/homer.bananaops.io_homerservices.yaml
+++ b/helm/homer-k8s/crds/homer.bananaops.io_homerservices.yaml
@@ -55,6 +55,9 @@ spec:
                             description: Optional color for card to set color directly
                               without custom stylesheet
                             type: string
+                          clipboard:
+                            description: Text to copy when type is clipboard
+                            type: string
                           icon:
                             description: Icon of service in homer dashboard, See https://fontawesome.com/v5/search
                               for icons options
@@ -83,6 +86,9 @@ spec:
                             type: string
                           target:
                             description: Target of the service in homer dashboard
+                            type: string
+                          type:
+                            description: Type of the service in homer dashboard
                             type: string
                           url:
                             description: Url of the service in homer dashboard


### PR DESCRIPTION
# Description

- Add a support clipboard type to the services section.
- Support non-v3-microarchitecture CPU (my cluster runs on non-v3-microarchitecture chip).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Built new image, update controller to use new image, tested with creating CRDs.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
